### PR TITLE
fix(missing_files): Just copy source file where secondary language fi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,25 @@
 
 ## How to
 
+### Windows Setup
+
 1. Download latest release.zip and unzip.
 2. Run textmerger.exe
-3. Enter the folder that the game .exe is located in (e.g for me it's C:\GOG Games\Tyranny). Use the ... button or just paste and press enter.
-4. Wait until it finds the languages.
-5. Choose the primary language and the secondary language. The primary language will be the main language of the game.
-6. Check the checkboxes you want to merge.
-7. Press 'Merge' and wait until it says it's done.
-8. In-game change the language to PrimaryLanguage/SecondaryLanguage (e.g English/French)
+
+### Mac/Linux Setup
+
+1. Download latest release.zip and unzip.
+2. Using Terminal.app(or any terminal app) run `python /path/to/folder/textmerger.py`
+
+### Steps for merging languages
+
+1. Enter the folder that the game .exe is located in (e.g for me it's C:\GOG Games\Tyranny). Use the ... button or just paste and press enter.
+2. Wait until it finds the languages.
+3. Choose the primary language and the secondary language. The primary language will be the main language of the game.
+4. Check the checkboxes you want to merge.
+5. Press 'Merge' and wait until it says it's done.
+6. In-game change the language to PrimaryLanguage/SecondaryLanguage (e.g English/French)
+
 
 This doesn't delete or replace the original languages but creates a new merged one.
 

--- a/textmerger.py
+++ b/textmerger.py
@@ -3,7 +3,8 @@ from tkinter import ttk
 from tkinter import messagebox
 from tkinter import *
 from pathlib import Path
-from shutil import copytree
+from shutil import copytree, copyfile
+import os
 
 import xml.etree.ElementTree as ET
 import ast
@@ -35,13 +36,13 @@ class App:
         #ROW ___
         self.convVar = IntVar()
         self.convVar.set(1)
-        self.conversationsCheck = Checkbutton(master, text="Conversations", variable = self.convVar)
+        self.conversationsCheck = Checkbutton(master, text="Conversations", bg='black', variable = self.convVar)
         self.questsVar = IntVar()
         self.questsVar.set(1)
-        self.questsCheck = Checkbutton(master, text="Quests", variable = self.questsVar)
+        self.questsCheck = Checkbutton(master, text="Quests", bg='black', variable = self.questsVar)
         self.gameVar = IntVar()
         self.gameVar.set(0)
-        self.gameCheck = Checkbutton(master, text= "Game", variable = self.gameVar)
+        self.gameCheck = Checkbutton(master, text= "Game", bg='black', variable = self.gameVar)
         #LAYOUT__
         self.pathLabel.grid(row=0, sticky=E)
         self.pathEntry.grid(row=0, column=1)
@@ -221,12 +222,16 @@ class App:
                     newFile.parent.mkdir(parents=True, exist_ok=True)
                     newFile.touch(exist_ok=True)
 
-                self.mergeFile(child, secondaryPath / child.name, newFile)
+                if os.path.isfile(secondaryPath / child.name):
+                    self.mergeFile(child, secondaryPath / child.name, newFile)
+                else:
+                    print('Missing secondary file, using source language only')
+                    copyfile(child, newFile)
 
             else:
                 continue
         return None
-
+      
     def mergeFile(self, primaryFile, secondaryFile, newFile):
         primaryTree = ET.parse(primaryFile)
         primaryRoot = primaryTree.getroot()

--- a/textmerger.py
+++ b/textmerger.py
@@ -6,6 +6,9 @@ from pathlib import Path
 from shutil import copytree, copyfile
 import os
 
+if os.name == 'nt': BCKGRND = None
+else: BCKGRND = 'black'
+
 import xml.etree.ElementTree as ET
 import ast
 
@@ -36,13 +39,13 @@ class App:
         #ROW ___
         self.convVar = IntVar()
         self.convVar.set(1)
-        self.conversationsCheck = Checkbutton(master, text="Conversations", bg='black', variable = self.convVar)
+        self.conversationsCheck = Checkbutton(master, text="Conversations", bg=BCKGRND, variable = self.convVar)
         self.questsVar = IntVar()
         self.questsVar.set(1)
-        self.questsCheck = Checkbutton(master, text="Quests", bg='black', variable = self.questsVar)
+        self.questsCheck = Checkbutton(master, text="Quests", bg=BCKGRND, variable = self.questsVar)
         self.gameVar = IntVar()
         self.gameVar.set(0)
-        self.gameCheck = Checkbutton(master, text= "Game", bg='black', variable = self.gameVar)
+        self.gameCheck = Checkbutton(master, text= "Game", bg=BCKGRND, variable = self.gameVar)
         #LAYOUT__
         self.pathLabel.grid(row=0, sticky=E)
         self.pathEntry.grid(row=0, column=1)


### PR DESCRIPTION
fix(missing_files): Just copy source file where secondary language fle is missing and fix(ui): Black bg so Mac can render checkbox text

The first issue occurs when using Russian as the secondary language, it seems some conversation files are missing.

The second is due to the white text on Mac on rendering on the UI, like so:
<img width="964" alt="Screenshot 2019-05-05 12 17 37" src="https://user-images.githubusercontent.com/167567/57193125-6fb43700-6f27-11e9-94ef-baad8f3edc48.png">

It's ugly fix but at least you can see what you're selecting now.

